### PR TITLE
Change PermissionCheckEvent to use phases and add an additional phase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def loaderVersion = '0.14.8'
 def fabricApiVersion = '0.57.0+1.19'
 
 group = 'me.lucko'
-version = '0.2-SNAPSHOT'
+version = '0.3-SNAPSHOT'
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraftVersion}"

--- a/src/main/java/me/lucko/fabric/api/permissions/v0/PermissionCheckEvent.java
+++ b/src/main/java/me/lucko/fabric/api/permissions/v0/PermissionCheckEvent.java
@@ -29,6 +29,7 @@ import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.command.CommandSource;
+import net.minecraft.util.Identifier;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -37,7 +38,10 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface PermissionCheckEvent {
 
-    Event<PermissionCheckEvent> EVENT = EventFactory.createArrayBacked(PermissionCheckEvent.class, (callbacks) -> (source, permission) -> {
+    // Used for mods that want to add permissions for a user that should take higher precedence over a permission handler.
+    Identifier BEFORE_HANDLERS = new Identifier("fabric-permissions-api", "before_handlers");
+
+    Event<PermissionCheckEvent> EVENT = EventFactory.createWithPhases(PermissionCheckEvent.class, (callbacks) -> (source, permission) -> {
         for (PermissionCheckEvent callback : callbacks) {
             TriState state = callback.onPermissionCheck(source, permission);
             if (state != TriState.DEFAULT) {
@@ -45,7 +49,7 @@ public interface PermissionCheckEvent {
             }
         }
         return TriState.DEFAULT;
-    });
+    }, BEFORE_HANDLERS, Event.DEFAULT_PHASE);
 
     @NotNull TriState onPermissionCheck(@NotNull CommandSource source, @NotNull String permission);
 


### PR DESCRIPTION
This would add a phase that would run before any permission handlers. 

Useful if someone has explicitly set permissions for users to false, but would want a content modifying mod to give them permissions if they meet certain conditions. 

a real use case is for my [professions](https://github.com/ExcessiveAmountsOfZombies/Professions) mod where server owners could give users permission if they reach a certain level in their occupation