### PR TITLE
Bump version to 0.3-SNAPSHOT

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -10,10 +10,10 @@ repositories {
 
 dependencies {
     // Approach #1: Ensure fabric-permissions-api is always available by including it within your own jar (it's only ~8KB!)
-    include(modImplementation('me.lucko:fabric-permissions-api:0.2-SNAPSHOT'))
+    include(modImplementation('me.lucko:fabric-permissions-api:0.3-SNAPSHOT'))
     
     // Approach #2: Depend on fabric-permissions-api, but require that users install it themselves
-    modImplementation 'me.lucko:fabric-permissions-api:0.2-SNAPSHOT'
+    modImplementation 'me.lucko:fabric-permissions-api:0.3-SNAPSHOT'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ def loaderVersion = '0.14.8'
 def fabricApiVersion = '0.57.0+1.19'
 
 group = 'me.lucko'
-version = '0.2-SNAPSHOT'
+version = '0.3-SNAPSHOT'
 
 dependencies {
     minecraft "com.mojang:minecraft:${minecraftVersion}"
@@ -41,7 +41,7 @@ tasks.withType(JavaCompile) {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
+    archiveClassifier = "sources"
     from sourceSets.main.allSource
 }
 


### PR DESCRIPTION
This is a very simple PR. It is mostly a notice / request to *please* bump the version of this library, because having different variations of it distributed with the same version name causes annoying issues. Bumping the version (assuming mod authors / library users will use the bumped version) should resolve the following (and probably many more) issues:
- https://github.com/lucko/fabric-permissions-api/issues/13
- https://github.com/lucko/fabric-permissions-api/issues/12
- https://github.com/lucko/fabric-permissions-api/issues/11
- https://github.com/DrexHD/VanillaPermissions/issues/8

If this is merged / implemented it would also be great to get a GitHub release to point people to.