### PR TITLE
Update to 1.21.6 (but in binary compatible way)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ def loaderVersion = '0.16.14'
 def fabricApiVersion = '0.126.0+1.21.6'
 
 group = 'me.lucko'
-version = '0.3.4-SNAPSHOT'
+version = '0.4.0-SNAPSHOT'
 description = 'A simple permissions API for Fabric'
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.7-SNAPSHOT'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
     id 'net.kyori.indra.publishing.sonatype' version '3.1.3'
     id 'net.kyori.indra.publishing' version '3.1.3'
@@ -9,10 +9,10 @@ repositories {
     maven { url 'https://maven.fabricmc.net/' }
 }
 
-def minecraftVersion = '1.21.3'
+def minecraftVersion = '1.21.6-pre3'
 def yarnBuild = 2
-def loaderVersion = '0.16.7'
-def fabricApiVersion = '0.106.1+1.21.3'
+def loaderVersion = '0.16.14'
+def fabricApiVersion = '0.126.0+1.21.6'
 
 group = 'me.lucko'
 version = '0.3.4-SNAPSHOT'
@@ -46,7 +46,7 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
-    options.release = 8
+    options.release = 21
 }
 
 indra {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/lucko/fabric/api/permissions/v0/Permissions.java
+++ b/src/main/java/me/lucko/fabric/api/permissions/v0/Permissions.java
@@ -81,7 +81,10 @@ public interface Permissions {
      * @return the result of the permission check
      */
     static boolean check(@NotNull CommandSource source, @NotNull String permission, int defaultRequiredLevel) {
-        return getPermissionValue(source, permission).orElseGet(() -> source instanceof PermissionLevelSource source1 ? source1.hasPermissionLevel(defaultRequiredLevel) : defaultRequiredLevel == 0);
+        return getPermissionValue(source, permission).orElseGet(() -> source instanceof PermissionLevelSource permissionSource
+                ? permissionSource.hasPermissionLevel(defaultRequiredLevel)
+                : defaultRequiredLevel == 0
+        );
     }
 
     /**

--- a/src/main/java/me/lucko/fabric/api/permissions/v0/Permissions.java
+++ b/src/main/java/me/lucko/fabric/api/permissions/v0/Permissions.java
@@ -28,6 +28,7 @@ package me.lucko.fabric.api.permissions.v0;
 import com.mojang.authlib.GameProfile;
 import net.fabricmc.fabric.api.util.TriState;
 import net.minecraft.command.CommandSource;
+import net.minecraft.command.PermissionLevelSource;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
@@ -80,7 +81,7 @@ public interface Permissions {
      * @return the result of the permission check
      */
     static boolean check(@NotNull CommandSource source, @NotNull String permission, int defaultRequiredLevel) {
-        return getPermissionValue(source, permission).orElseGet(() -> source.hasPermissionLevel(defaultRequiredLevel));
+        return getPermissionValue(source, permission).orElseGet(() -> source instanceof PermissionLevelSource source1 ? source1.hasPermissionLevel(defaultRequiredLevel) : defaultRequiredLevel == 0);
     }
 
     /**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -12,7 +12,8 @@
   "entrypoints": {},
   "depends": {
     "fabricloader": ">=0.9.0",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "minecraft": ">=1.21.6-"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
Makes the api compatible with 1.21.6, while keeping it binary compatible with older mods using it (as quite few server side 1.21.5 mods require no to minimal changes to work, so no reason to require them to recompile)