### PR TITLE
Fix NullPointerException when using OfflineOptionRequestEvent

### DIFF
--- a/src/main/java/me/lucko/fabric/api/permissions/v0/OfflineOptionRequestEvent.java
+++ b/src/main/java/me/lucko/fabric/api/permissions/v0/OfflineOptionRequestEvent.java
@@ -39,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 public interface OfflineOptionRequestEvent {
 
     Event<OfflineOptionRequestEvent> EVENT = EventFactory.createArrayBacked(OfflineOptionRequestEvent.class, (callbacks) -> (uuid, key) -> {
-        CompletableFuture<Optional<String>> res = CompletableFuture.completedFuture(null);
+        CompletableFuture<Optional<String>> res = CompletableFuture.completedFuture(Optional.empty());
         for (OfflineOptionRequestEvent callback : callbacks) {
             res = res.thenCompose(value -> {
                 if (value.isPresent()) {


### PR DESCRIPTION
The initial value was set to null, which caused the call to value.isPresent() to throw a NPE

related to https://github.com/LuckPerms/LuckPerms/issues/4120